### PR TITLE
[AD-6] Create Travis CI account

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,12 @@
 language: node_js
 sudo: false
 node_js:
-  - 4
   - 5
-  - 6
 os:
   - linux
-  - centos
-  - macosx
-  - windows
 # NodeJS v4 requires gcc 4.8
 env:
   - NODE_ENV=travis CXX="g++-4.8" CC="gcc-4.8"
-matrix:
-  allow_failures:
-    - node_js: 6
 services:
   - mongodb
 # gcc 4.8 requires ubuntu-toolchain-r-test


### PR DESCRIPTION
Change travis ci config to test only using node v5 in linux OS,
because that is most likely our production environment.
