### PR TITLE
Addding protractor-uisref-locator dependency and setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "load-grunt-tasks": "~3.4.1",
     "mock-fs": "~3.7.0",
     "node-inspector": "~0.12.7",
+    "protractor-uisref-locator": "^1.2.0",
     "run-sequence": "~1.1.5",
     "should": "~8.2.2",
     "supertest": "~1.2.0"

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -2,7 +2,10 @@
 
 // Protractor configuration
 var config = {
-  specs: ['modules/*/tests/e2e/*.js']
+  specs: ['modules/*/tests/e2e/*.js'],
+  onPrepare: function () {
+    require('protractor-uisref-locator')(protractor);
+  }
 };
 
 if (process.env.TRAVIS) {


### PR DESCRIPTION
Adding protractor-uisref-locator as a dependency in order to be able to locate elements by uiSref in protractor. This is only useful if we use a lot of uiSref and given that MEAN js uses a lot of them, it might help us test easier.
